### PR TITLE
modify runtime/tests/communication/README.md

### DIFF
--- a/runtime/tests/communication/README.md
+++ b/runtime/tests/communication/README.md
@@ -10,6 +10,6 @@ python point_to_point.py --backend gloo --master_addr localhost --rank 1 --maste
 To run the `gloo_communication_handler` test that uses PipeDream's communication
 library, run
 ```bash
-python gloo_communication_handler.py --backend gloo --master_addr localhost --rank 0 --master_port 8888 &
-python gloo_communication_handler.py --backend gloo --master_addr localhost --rank 1 --master_port 8888
+python gloo_communication_handler.py --master_addr localhost --rank 0 --master_port 8888 &
+python gloo_communication_handler.py --master_addr localhost --rank 1 --master_port 8888
 ```


### PR DESCRIPTION
`runtime/tests/communication/gloo_communication_handler.py` doesn't have `--backend` argument