### PR TITLE
modify runtime/image_classification/models/resnet50/gpus=2/__init__.py

### DIFF
--- a/runtime/image_classification/models/resnet50/gpus=2/__init__.py
+++ b/runtime/image_classification/models/resnet50/gpus=2/__init__.py
@@ -12,7 +12,7 @@ def arch():
 
 def model(criterion):
     return [
-        (Stage0(), ["input"], ["out0", "out1"]),
+        (Stage0(), ["input0"], ["out0", "out1"]),
         (Stage1(), ["out0", "out1"], ["out3", "out2"]),
         (Stage2(), ["out3", "out2"], ["out4", "out5"]),
         (Stage3(), ["out4", "out5"], ["out6"]),


### PR DESCRIPTION
Hello, I found some bug in resnet50 gpus 2 experiment code.
A keyerror was raised when running the experiment.
```
Traceback (most recent call last):
  File "main_with_runtime.py", line 585, in <module>
    main()
  File "main_with_runtime.py", line 146, in main
    input_tensor = torch.zeros(tuple(training_tensor_shapes[input]),
KeyError: 'input'
```
So I modified runtime/image_classification/models/resnet50/gpus=2/__init__.py file and saw it works.